### PR TITLE
Remove doubled slash in quicklink.min.js URL

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -14,7 +14,7 @@ If you’re filing a bug, specific steps to reproduce are helpful. Please includ
 
 Every theme is just as good as the documentation. In this repository we offer [collaboration with a wiki](https://github.com/luehrsenheinrich/quicklink/wiki) to create a documentation for this theme.
 
-## Setting up the dev enviroment
+## Setting up the dev environment
 
 If you want to contribute code to the theme you have to set up the environment locally. Make sure that you have `npm` and `grunt` installed.
 

--- a/build/quicklink.php
+++ b/build/quicklink.php
@@ -44,6 +44,6 @@ register_deactivation_hook( __FILE__, 'deactivate_quicklink' );
  * Embed the scripts we need for this plugin
  */
 function quicklink_enqueue_scripts() {
-	wp_enqueue_script( 'quicklink', QUICKLINK_URL . '/quicklink.min.js', array(), '<##= pkg.version ##>', true );
+	wp_enqueue_script( 'quicklink', QUICKLINK_URL . 'quicklink.min.js', array(), '<##= pkg.version ##>', true );
 }
 add_action( 'wp_enqueue_scripts', 'quicklink_enqueue_scripts' );


### PR DESCRIPTION
When activating the plugin I noticed there is a doubled slash in the enqueued script URL:

```html
<script type='text/javascript' src='https://wordpressdev.lndo.site/content/plugins/quicklink//quicklink.min.js?ver=0.2.0'></script>
```

This fixes that, and also fixes a typo.