### PR TITLE
Add compatibility with AMP plugin

### DIFF
--- a/build/quicklink.php
+++ b/build/quicklink.php
@@ -44,6 +44,11 @@ register_deactivation_hook( __FILE__, 'deactivate_quicklink' );
  * Embed the scripts we need for this plugin
  */
 function quicklink_enqueue_scripts() {
+	// Abort if the response is AMP since custom JavaScript isn't allowed and Quicklink functionality would be part of the AMP runtime.
+	if ( function_exists( 'is_amp_endpoint' ) && is_amp_endpoint() ) {
+		return;
+	}
+
 	wp_enqueue_script( 'quicklink', QUICKLINK_URL . 'quicklink.min.js', array(), '<##= pkg.version ##>', true );
 }
 add_action( 'wp_enqueue_scripts', 'quicklink_enqueue_scripts' );


### PR DESCRIPTION
Custom JavaScript is not allowed in AMP, and the Quicklink functionality should be part of the AMP runtime itself. Since the AMP plugin will report the enqueued `script` as a validation error and sanitize it, we can avoid enqueueing it to begin with when it is an AMP page.